### PR TITLE
Debug chart links in Studies chart coverage

### DIFF
--- a/obiba_mica_commons/includes/obiba_mica.inc
+++ b/obiba_mica_commons/includes/obiba_mica.inc
@@ -605,15 +605,16 @@ class MicaClient {
       $ordered_taxonomies = self::getTaxonomiesAsArray($order_taxonomy_variable);
       $taxonomies = array_map(
         function ($n) use ($taxonomies, $getter) {
-        $tmp = array_filter($taxonomies,
-          function ($t) use ($n, $getter) {
-            return $getter($t) === $n;
-          }
-        );
-        return reset($tmp);
+          $tmp = array_filter($taxonomies,
+            function ($t) use ($n, $getter) {
+              return $getter($t) === $n;
+            }
+          );
+          return reset($tmp);
         }
-      , $ordered_taxonomies);
-      $taxonomies = array_filter($taxonomies, function ($t) {return !empty($t);
+        , $ordered_taxonomies);
+      $taxonomies = array_filter($taxonomies, function ($t) {
+        return !empty($t);
       }
       );
     }
@@ -959,16 +960,17 @@ class MicaClient {
   public static function chartQueryBuilders($query = NULL, $bucket = NULL, $taxonomy_name = NULL, $vocabulary_name = NULL, array $terms = NULL) {
     $parameters = array();
     $current_path_alias = drupal_get_path_alias();
+    $current_path_alias = explode('/[', $current_path_alias)[0];
     $common_param
       = array(
-        'variables' => array(
-          'terms' => array(
-            'attributes-'
-            . $taxonomy_name . '__' .
-            $vocabulary_name . '-und' => $terms,
-          ),
+      'variables' => array(
+        'terms' => array(
+          'attributes-'
+          . $taxonomy_name . '__' .
+          $vocabulary_name . '-und' => $terms,
         ),
-      );
+      ),
+    );
     if (!empty($query)) {
       return json_encode(MicaClient::concatenateParameterTerms(json_decode($query), $common_param));
     }
@@ -979,6 +981,11 @@ class MicaClient {
             $bucket->field => $bucket->value,
           ),
         ),
+        'networks' => array(
+          'terms' => array(
+            'networkId' => arg(2, $current_path_alias),
+          ),
+        ),
       );
     }
     if (strpos($current_path_alias, 'study')) {
@@ -986,6 +993,17 @@ class MicaClient {
         'studies' => array(
           'terms' => array(
             'studyIds' => arg(2, $current_path_alias),
+          ),
+        ),
+      );
+      $common_param
+        = array(
+        'variables' => array(
+          'terms' => array(
+            'attributes-'
+            . $taxonomy_name . '__' .
+            $vocabulary_name . '-und' => $terms,
+            $bucket->field => $bucket->value,
           ),
         ),
       );

--- a/obiba_mica_dataset/obiba_mica_dataset-page-detail.inc
+++ b/obiba_mica_dataset/obiba_mica_dataset-page-detail.inc
@@ -524,7 +524,14 @@ function obiba_mica_dataset_harmonizations_table_data($dataset_type_dto, $datase
 function obiba_mica_dataset_coverage($dataset_id) {
   $coverage['charts'] = obiba_mica_search_query_charts(
     MicaClient::addParameterDtoQueryLink(
-      array('variables' => array('terms' => array('datasetId' => $dataset_id)))), NULL, NULL,
+      array(
+        'variables' => array(
+          'terms' => array(
+            'datasetId' => $dataset_id
+          )
+        )
+      )
+    ), NULL, NULL,
     array('with-facets' => 'false'));
   if (!empty($coverage['charts'])) {
     $coverage['has_coverage'] = TRUE;

--- a/obiba_mica_search/obiba_mica_search.info
+++ b/obiba_mica_search/obiba_mica_search.info
@@ -4,4 +4,3 @@ package = Obiba
 core = 7.x
 
 dependencies[] = obiba_mica_commons
-dependencies[] = charts_google

--- a/obiba_mica_search/obiba_mica_search_charts.php
+++ b/obiba_mica_search/obiba_mica_search_charts.php
@@ -207,7 +207,7 @@ function obiba_mica_search_query_charts($query, Callable $bucket_filter = NULL, 
       foreach ($link as $key) {
         $links[] = $key;
       }
-//      dpm($links2);
+
       if (!empty($data)) {
         $parser_data['data'] = $data;
         $parser_data['links'] = !empty($links) ? $links : NULL;

--- a/obiba_mica_study/obiba_mica_study-page-detail.inc
+++ b/obiba_mica_study/obiba_mica_study-page-detail.inc
@@ -332,11 +332,14 @@ function obiba_mica_study_get_variables($study_id) {
 
 function obiba_mica_study_coverage($study_id) {
   $coverage['charts'] = obiba_mica_search_query_charts(
-    MicaClient::addParameterDtoQueryLink(array('variables' => array('terms' => array('studyIds' => $study_id)))),
+    MicaClient::addParameterDtoQueryLink(array('variables' => array(
+      'terms' => array(
+        'studyIds' => $study_id)))),
     function ($b, $study_id) {
       // filter the dces of the current study
       return strpos($b->value, ':') === FALSE || strpos($b->value, $study_id . ':') === 0;
-    }, $study_id,
+    },
+    $study_id,
     array('group-by' => 'dceIds', 'with-facets' => 'false'));
   if (!empty($coverage['charts'])) {
     $coverage['has_coverage'] = TRUE;


### PR DESCRIPTION
Enhancement precision of links queries
Debug chart links in Studies chart coverage
Remove charts_google from dependencies : may cause crash installation of obiba_mica module with drush command
(can be enabled after success installation of obiba_mica ) 