### PR TITLE
Fix To avoid error installation of obiba_mica module

### DIFF
--- a/obiba_mica_commons/includes/obiba_mica_commons_taxonomy_resource.inc
+++ b/obiba_mica_commons/includes/obiba_mica_commons_taxonomy_resource.inc
@@ -14,6 +14,7 @@
  * MicaStudyResource class
  */
 
+include_once('obiba_mica.inc');
 /**
  * Class MicaStudyResource
  */

--- a/obiba_mica_dataset/obiba_mica_dataset.module
+++ b/obiba_mica_dataset/obiba_mica_dataset.module
@@ -14,6 +14,8 @@
  * Code for obiba_mica_dataset module.
  */
 
+$path_module_commons = drupal_get_path('module', 'obiba_mica');
+include_once($path_module_commons . '/obiba_mica.constants.inc');
 include_once('obiba_mica_dataset_admin_form.inc');
 
 /**


### PR DESCRIPTION
Must be in 7.x-4.x and 7.x-5.x
 Not needed in master WIP to optimise autoload of classes