### PR TITLE
Php Error handler

### DIFF
--- a/obiba_mica.module
+++ b/obiba_mica.module
@@ -17,6 +17,23 @@
 $path_module_study = drupal_get_path('module', 'obiba_mica_study');
 include_once($path_module_study . '/obiba_mica_study-page-list.inc');
 
+
+/**
+ * Implements hook_init().
+ *
+ * We cannot use hook_boot() because the url() function is
+ * not available at this time.
+ */
+function obiba_mica_init() {
+  if (class_exists('Obiba\ObibaMicaClient\MicaClient\DrupalMicaClient\MicaClient')) {
+    register_shutdown_function(array(
+      'DrupalMicaClientResource',
+      'DrupalMicaErrorHandler'
+    ));
+    define('HIDE_PHP_FATAL_ERROR_URL', url(variable_get('custom_fatal_error_page', 'site-error')));
+  }
+}
+
 /**
  * Implements hook_menu().
  */
@@ -66,8 +83,75 @@ function obiba_mica_menu() {
     'file' => 'obiba_mica_content_pages.admin.inc',
     'weight' => 1,
   );
+
+
+  $items['site-error'] = array(
+    'title' => 'Site error',
+    'page callback' => 'obiba_mica_fatal_error_page',
+    'access callback' => TRUE,
+    'type' => MENU_CALLBACK,
+  );
+
   return $items;
 }
+
+/**
+ * Menu callback; display a nice error page.
+ */
+function obiba_mica_fatal_error_page() {
+  $parameters = drupal_get_query_parameters();
+  $error_message = t('The web server is returning an internal error.');
+  $destination = !empty($parameters['destination']) ? $parameters['destination'] : '';
+  $error_page_link = l(t('Try This Page Again'), $destination, array(
+    'attributes' => array(
+      'class' =>
+        array('btn btn-default btn-lg text-center')
+    )
+  ));
+  $my_header_body_content = <<<EOF
+    <div class='container'>
+  <div class='jumbotron'>
+    <h1><span class='glyphicon glyphicon-fire red'></span> $destination</h1>
+    <p class='lead'>$error_message<em><span id='display-domain'></span></em>.</p>
+    $error_page_link
+  </div>
+</div>
+EOF;
+
+
+  $drupal_error_page_node = obiba_mica_commons_get_translated_node(variable_get_value('drupal_error_page'));
+  if (!empty($drupal_error_page_node)) {
+    drupal_set_title($drupal_error_page_node['#node']->title);
+    $drupal_error_page = $drupal_error_page_node;
+  }
+  else {
+    $my_body_content = <<<EOF
+<div class='container'>
+  <div class='body-content'>
+    <div class='row'>
+      <div class='col-md-6'>
+        <h2>What happened?</h2>
+        <p class='lead'>A 500 error status implies there is a problem with the web server's software causing it to malfunction.</p>
+      </div>
+      <div class='col-md-6'>
+        <h2>What can I do?</h2>
+        <p class='lead'>If you're a site visitor</p>
+        <p>Nothing you can do at the moment. The administrators will resolve the problem as soon as possible. If you need immediate assistance, please send us an email instead. We apologize for any inconvenience.</p>
+        <p>Please Try again later</p>
+     </div>
+    </div>
+  </div>
+</div>
+EOF;
+
+    $drupal_error_page_node = obiba_mica_commons_add_page(t('Error Page'), $my_body_content);
+    variable_set('drupal_error_page', $drupal_error_page_node->nid);
+    $drupal_error_page = node_view(node_load(variable_get_value('drupal_error_page')));
+  }
+  $drupal_error_page_node['#node']->title = '';
+  return $my_header_body_content . render($drupal_error_page);
+}
+
 
 /**
  * Implements hook_permission().

--- a/obiba_mica_commons/includes/obiba_mica_commons_autoload.inc
+++ b/obiba_mica_commons/includes/obiba_mica_commons_autoload.inc
@@ -17,6 +17,45 @@ if(class_exists('Obiba\ObibaMicaClient\MicaClient\DrupalMicaClient\MicaClient'))
         new MicaConfig\MicaDrupalConfig(),
         new MicaWatchDog\MicaDrupalClientWatchDog());
     }
+    public static function DrupalMicaErrorHandler($force = NULL,  $message_parameters = NULL){
+      $current_path = current_path();
+      if($force){
+        drupal_set_message(t($message_parameters['message'],
+          $message_parameters['placeholders']),
+          $message_parameters['severity']);
+        throw new MyException('Server Error');
+        header('Location: ' . HIDE_PHP_FATAL_ERROR_URL . '?destination=' . $current_path, FALSE);
+      }
+      if((!is_null($error = error_get_last()) && $error['type'] === E_ERROR)) {
+        header('Location: ' . HIDE_PHP_FATAL_ERROR_URL . '?destination=' . $current_path);
+
+        // We need to reuse the code from _drupal_error_handler_real() to
+        // force the maintenance page.
+        require_once DRUPAL_ROOT . '/includes/errors.inc';
+
+        $types = drupal_error_levels();
+        list($severity_msg, $severity_level) = $types[$error['type']];
+
+        if (!function_exists('filter_xss_admin')) {
+          require_once DRUPAL_ROOT . '/includes/common.inc';
+        }
+
+        // We consider recoverable errors as fatal.
+        $error = array(
+          '%type' => isset($types[$error['type']]) ? $severity_msg : 'Unknown error',
+          // The standard PHP error handler considers that the error messages
+          // are HTML. We mimick this behavior here.
+          '!message' => filter_xss_admin($error['message']),
+          '%file' => $error['file'],
+          '%line' => $error['line'],
+          'severity_level' => $severity_level,
+        );
+
+        watchdog('php', '%type: !message (line %line of %file).', $error, $error['severity_level']);
+        exit;
+      }
+    }
+
   }
 }
 else{

--- a/obiba_mica_network/includes/obiba_mica_network_resource.inc
+++ b/obiba_mica_network/includes/obiba_mica_network_resource.inc
@@ -50,7 +50,7 @@ class DrupalMicaNetworkResource extends DrupalMicaClientResource {
       $params = "network(exists(Mica_network.id),limit($from,$limit)$sort_rql_bucket)";
     }
     $params .= ",locale($language->language)";
-    $resource_query ='/networks/_rql?query=' . $params;
+    $resource_query = '/networks/_rql?query=' . $params;
 
     $cache_stored_data = $this->drupalCache->MicaGetCache(__FUNCTION__ . $resource_query);
     if (!empty($cache_stored_data)) {
@@ -82,10 +82,19 @@ class DrupalMicaNetworkResource extends DrupalMicaClientResource {
             '@code' => $e->getCode(),
             '@message' => $e->getMessage()
           ), WATCHDOG_WARNING);
-        return array();
+        $message_parameters['message'] = 'Connection to server fail,  Error serve code : @code, message: @message';
+        $message_parameters['placeholders'] = array(
+          '@code' => $e->getCode(),
+          '@message' => $e->getMessage()
+        );
+        $message_parameters['severity'] = 'error';
+        if ($e->getCode() == 500 || $e->getCode() == 503 || $e->getCode() == 0) {
+          DrupalMicaClientResource::DrupalMicaErrorHandler(TRUE, $message_parameters);
+        }
+        drupal_set_message(t($message_parameters['message'],$message_parameters['placeholders']),  $message_parameters['severity']);
       }
     }
-    return False;
+    return FALSE;
   }
 
 
@@ -102,7 +111,7 @@ class DrupalMicaNetworkResource extends DrupalMicaClientResource {
     if (!empty($cache_stored_data)) {
       return $cache_stored_data;
     }
-    else{
+    else {
       $url_networks = $this->micaUrl . $resource_query;
       $request = new HttpClientRequest($url_networks, array(
         'method' => HttpClientRequest::METHOD_GET,
@@ -119,9 +128,9 @@ class DrupalMicaNetworkResource extends DrupalMicaClientResource {
         if (!empty($response->networkResultDto) && !empty($response->networkResultDto->{'obiba.mica.NetworkResultDto.result'})) {
           $result_resource_query = $response->networkResultDto->{'obiba.mica.NetworkResultDto.result'};
         }
-        if(!empty($result_resource_query)){
-        $this->drupalCache->MicaSetCache(__FUNCTION__ . $resource_query, $result_resource_query);
-        return $result_resource_query;
+        if (!empty($result_resource_query)) {
+          $this->drupalCache->MicaSetCache(__FUNCTION__ . $resource_query, $result_resource_query);
+          return $result_resource_query;
         }
       } catch (HttpClientException $e) {
         watchdog('Mica Client', 'Connection to server fail,  Error serve code : @code, message: @message',
@@ -129,8 +138,16 @@ class DrupalMicaNetworkResource extends DrupalMicaClientResource {
             '@code' => $e->getCode(),
             '@message' => $e->getMessage()
           ), WATCHDOG_WARNING);
-
-        return array();
+        $message_parameters['message'] = 'Connection to server fail,  Error serve code : @code, message: @message';
+        $message_parameters['placeholders'] = array(
+          '@code' => $e->getCode(),
+          '@message' => $e->getMessage()
+        );
+        $message_parameters['severity'] = 'error';
+        if ($e->getCode() == 500 || $e->getCode() == 503 || $e->getCode() == 0) {
+          DrupalMicaClientResource::DrupalMicaErrorHandler(TRUE, $message_parameters);
+        }
+        drupal_set_message(t($message_parameters['message'],$message_parameters['placeholders']),  $message_parameters['severity']);
       }
     }
     return FALSE;
@@ -146,7 +163,7 @@ class DrupalMicaNetworkResource extends DrupalMicaClientResource {
     $resource_query = '/network/' . rawurlencode($network_id);
     $this->setLastResponse(NULL);
     $cached_network = $this->drupalCache->MicaGetCache(__FUNCTION__ . $resource_query);
-    if(!empty($cached_network)){
+    if (!empty($cached_network)) {
       return $cached_network;
     }
     else {
@@ -171,7 +188,21 @@ class DrupalMicaNetworkResource extends DrupalMicaClientResource {
           return $network_response;
         }
       } catch (HttpClientException $e) {
-        return array();
+        watchdog('Mica Client', 'Connection to server fail,  Error serve code : @code, message: @message',
+          array(
+            '@code' => $e->getCode(),
+            '@message' => $e->getMessage()
+          ), WATCHDOG_WARNING);
+        $message_parameters['message'] = 'Connection to server fail,  Error serve code : @code, message: @message';
+        $message_parameters['placeholders'] = array(
+          '@code' => $e->getCode(),
+          '@message' => $e->getMessage()
+        );
+        $message_parameters['severity'] = 'error';
+        if ($e->getCode() == 500 || $e->getCode() == 503 || $e->getCode() == 0) {
+          DrupalMicaClientResource::DrupalMicaErrorHandler(TRUE, $message_parameters);
+        }
+        drupal_set_message(t($message_parameters['message'],$message_parameters['placeholders']),  $message_parameters['severity']);
       }
     }
   }

--- a/obiba_mica_network/obiba_mica_network-page-detail.inc
+++ b/obiba_mica_network/obiba_mica_network-page-detail.inc
@@ -154,7 +154,7 @@ function obiba_mica_network_page_detail($network_id) {
     }
   }
   else {
-    drupal_set_title(t('Network not found'));
+    drupal_set_title('Something wrong with this network');
     return '';
   }
 }


### PR DESCRIPTION
Redirect eventual php error caused by Obiba_mica module to a fancy page, also it can detect if mica sever is down.
It Can't handler the ajax call errors may be it have to be implemented in client side (Angular search, etc ...)