### PR TITLE
MK-1149 -  variable not set for some theme renders (mica_dce_detail, …

### DIFF
--- a/obiba_mica_dataset/obiba_mica_dataset-page-detail.inc
+++ b/obiba_mica_dataset/obiba_mica_dataset-page-detail.inc
@@ -140,6 +140,7 @@ function obiba_mica_dataset_page_detail($dataset_id) {
       $permissionResource = new DrupalMicaClient\DrupalMicaClientPermission();
       $can_edit_draf_document = $permissionResource->canEditDraftDocument($dataset_dto);
       $dataset_theme = theme('obiba_mica_dataset-detail', array(
+        'localize' => obiba_mica_commons_mica_server_localisation(),
         'can_edit_draf_document' => $can_edit_draf_document ? $can_edit_draf_document : FALSE,
         'dataset_dto' => $dataset_dto,
         'coverage' => !empty($coverage) ? $coverage['charts'] : NULL,
@@ -224,6 +225,7 @@ function obiba_mica_dataset_get_population_dce_modals($study_id, $data, $variabl
       $modals['population'][] = theme('mica_population_content_detail_modal', array(
         'population' => $population,
         'population_content' => theme('mica_population_content_detail', array(
+          'localize' => obiba_mica_commons_mica_server_localisation(),
           'dce_uids' => $dce_uids,
           'population' => $population,
           'hide_title' => TRUE,
@@ -252,6 +254,7 @@ function obiba_mica_dataset_get_population_dce_modals($study_id, $data, $variabl
         $dce_variables_nbr[obiba_mica_commons_get_localized_field($dce, 'name')] = $variables_dataset->total;
 
         $modals['dce'] .= theme('mica_dce_detail', array(
+          'localize' => obiba_mica_commons_mica_server_localisation(),
           'has_coverage' => $has_coverage,
           'dce_variables_nbr' => $dce_variables_nbr,
           'study_id' => $study_id,


### PR DESCRIPTION
…obiba_mica_study_detail and mica_population_content_detail).
using "localize-" as search query shows its usage in the pages pages obiba_mica_study-dce-detail (mica_dce_detail), obiba_mica_study-detail (obiba_mica_study_detail), obiba_mica_study-population-content-detail (mica_population_content_detail).

Added the variable in the only theme render calls where tit was missing. 