### PR TITLE
MK-1137 - resolve jquery to 2.2.4

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -31,6 +31,6 @@
   },
   "resolutions": {
     "angular": "1.5.5",
-    "jquery": "2.1.4"
+    "jquery": "2.2.4"
   }
 }


### PR DESCRIPTION
This would be the dame version as in mica2 admin. However, like Samir mentioned in the jira, drupal will use 1.10. 