### PR TITLE
MK-1180 - fix for the dce description

### DIFF
--- a/obiba_mica_study/obiba_mica_study-page-detail.inc
+++ b/obiba_mica_study/obiba_mica_study-page-detail.inc
@@ -386,7 +386,7 @@ function obiba_mica_study_get_dce_table($data_collection_events, $study_id, $pop
   foreach ($data_collection_events as $key_dce => $dce_wrapper) {
     $dce_description = NULL;
     if (!empty($dce_wrapper->model->description)) {
-      $dce_description = obiba_mica_commons_markdown(truncate_utf8(strip_tags(obiba_mica_commons_get_localized_field($dce_wrapper->model, 'description')), 50, TRUE, TRUE));
+      $dce_description = obiba_mica_commons_markdown(truncate_utf8(strip_tags(obiba_mica_commons_get_localized_field($dce_wrapper, 'description')), 50, TRUE, TRUE));
     }
     // Hide DCE that are not published on study published page
 

--- a/obiba_mica_study/templates/obiba_mica_study-dce-detail.tpl.php
+++ b/obiba_mica_study/templates/obiba_mica_study-dce-detail.tpl.php
@@ -24,9 +24,9 @@ $dce_name = obiba_mica_commons_get_localized_field($dce, 'name');
       <div class="modal-body">
         <section>
           <div>
-            <?php if (!empty($dce->model->description)): ?>
+            <?php if (!empty($dce->description)): ?>
               <p>
-                <?php print obiba_mica_commons_markdown(obiba_mica_commons_get_localized_field($dce->model, 'description')); ?>
+                <?php print obiba_mica_commons_markdown(obiba_mica_commons_get_localized_field($dce, 'description')); ?>
               </p>
             <?php endif; ?>
           </div>


### PR DESCRIPTION
The dce description will be truncated at 50+ characters in the dce table. If it is the markdown might not render the text and leave it as is but suffixed with ellipses.