### PR TITLE
MK-1191 - fix for bug anchor to population

### DIFF
--- a/obiba_mica_graphic/js/app/obiba-mica-graphic-controller.js
+++ b/obiba_mica_graphic/js/app/obiba-mica-graphic-controller.js
@@ -217,7 +217,7 @@
 
       // type and id
       var absUrl = $location.absUrl();
-      var re = /\/mica\/(\S+)\/(\S+)$/;
+      var re = /\/mica\/([a-z_-]+)\/([a-z_-]+)(?:\/#)?/;
       var found = absUrl.match(re);
 
       if (found) {

--- a/obiba_mica_study/js/mica-study-detail.js
+++ b/obiba_mica_study/js/mica-study-detail.js
@@ -75,9 +75,13 @@
         var anchor = location.hash.substr(1)? location.hash.substr(1).replace(/^\//, '') :null;
         if(anchor) {
           $('#tab-pane a[href="#' + anchor + '"]').tab('show');
-          $('html, body').animate({
-            scrollTop: $('#'+ anchor).offset().top
-          }, 'slow');
+          var scrollSpot = $('#'+ anchor);
+
+          if (scrollSpot.length) {
+            $('html, body').animate({
+              scrollTop: scrollSpot.offset().top
+            }, 'slow');
+          }
         }
       }
     }

--- a/obiba_mica_study/templates/obiba_mica_study-detail.tpl.php
+++ b/obiba_mica_study/templates/obiba_mica_study-detail.tpl.php
@@ -352,7 +352,7 @@
       <h2 id="populations"><?php if (count($populations) > 1) {
           print t('Populations');
         }
-        else print t('Population') ?></h2>
+        else print '<span id="population-' . $key . '">' . t('Population') . '</span>' ?></h2>
       <?php if (count($populations) == 1): ?>
         <?php print array_pop($populations)['html']; ?>
       <?php else: ?>


### PR DESCRIPTION
First have a check for the presence of the scroll position.
Add the html id to the 'Population' title when study has only one population such that the page would scroll to that spot.

Also fixed an error in the variable classification for when a hash is present.