### PR TITLE
MK-1262

### DIFF
--- a/obiba_mica_dataset/obiba_mica_dataset-page-detail.inc
+++ b/obiba_mica_dataset/obiba_mica_dataset-page-detail.inc
@@ -627,7 +627,7 @@ function obiba_mica_dataset_harmonizations_table_data($dataset_type_dto, $datase
           $key_row = str_replace(' ', '_', $key_row);
           if ($found) {
           foreach ($variable_harmonization->datasetVariableSummaries as $variable_summary) {
-            if (($variable_summary->resolver->studyId == $opal_table->studyId && $variable_summary->resolver->networkTableId == $opal_table->networkId)
+            if (($variable_summary->resolver->studyId == $opal_table->studyId && @$variable_summary->resolver->networkTableId == @$opal_table->networkId)
               && $variable_summary->resolver->project == $opal_table->project
               && $variable_summary->resolver->table == $opal_table->table) {
               $status = obiba_mica_dataset_variable_attributes_detail($variable_summary, 'status', array(


### PR DESCRIPTION
Harmo dataset variables table is super slow to display
notice php message logged in drupal database cause a performance issue (~1080 watchDog calls in the harminazation table) due to not unavailability of $variable_summary->resolver->networkTableId or/and $opal_table->networkId
 We have to consider disabling Database Logging drupal module to increase performance in Production environment
Database logging enabled => no cache > 55s ~ 1min / cached > ~980ms
Database logging Disabled => no cache > 5 ~ 6.5 s / cache > 880ms ~ 940 ms