### PR TITLE
MK-1618

### DIFF
--- a/obiba_mica_lists/includes/obiba_mica_lists_helpers.inc
+++ b/obiba_mica_lists/includes/obiba_mica_lists_helpers.inc
@@ -17,6 +17,12 @@
 
 
 class MicaListsHelper{
+
+  const TARGET_STUDY = 'study';
+  const TARGET_NETWORK = 'network';
+  const TARGET_DATASET = 'dataset';
+  const TARGET_VARIABLE = 'variable';
+
   static function studyFragment($type = NULL) {
     $study_sort = variable_get_value('study_list_name_acronym_sort');
     $study_order = (!empty(variable_get_value('study_list_default_order_sort') && variable_get_value('study_list_default_order_sort') == 'desc'))

--- a/obiba_mica_lists/js/app/obiba-lists.js
+++ b/obiba_mica_lists/js/app/obiba-lists.js
@@ -27,6 +27,12 @@ mica.ObibaLists = angular.module('mica.ObibaLists', [
     if(Drupal.settings.obibaListOptions.studyOptions){
       Drupal.settings.obibaListSearchOptions.studies.obibaListOptions = Drupal.settings.obibaListOptions.studyOptions;
     }
+    if(Drupal.settings.obibaListOptions.networkOptions){
+      Drupal.settings.obibaListSearchOptions.networks.obibaListOptions = Drupal.settings.obibaListOptions.networkOptions;
+    }
+    if(Drupal.settings.obibaListOptions.datasetOptions){
+      Drupal.settings.obibaListSearchOptions.datasets.obibaListOptions = Drupal.settings.obibaListOptions.datasetOptions;
+    }
     ngObibaMicaSearchProvider.setOptions(Drupal.settings.obibaListSearchOptions);
     if(Drupal.settings.listOverrideThemes){
       angular.forEach(Drupal.settings.listOverrideThemes, function (template, keyTemplate) {

--- a/obiba_mica_lists/obiba_mica_lists.module
+++ b/obiba_mica_lists/obiba_mica_lists.module
@@ -153,10 +153,22 @@ function obiba_mica_lists_get_js($weight_js) {
   return ++$weight_js;
 }
 
+function obiba_mica_lists_get_array_value_variable($variable){
+  return array_values(array_filter(array_map('trim', explode(',', variable_get_value($variable)))));
+}
+
+function obiba_mica_lists_item_to_show($tabs, $item){
+  if(in_array($item, $tabs)){
+    return TRUE;
+  }
+  return FALSE;
+}
+
 /*
  * Networks list options
  */
 function obiba_mica_lists_networks_options(){
+  $tabs_config = obiba_mica_lists_get_array_value_variable('mica_result_tabs_order');
   $acronym_name_sort = variable_get_value('network_list_default_field_sort');
   $networks_options = array(
     'listSearchOptions' => array(
@@ -171,6 +183,11 @@ function obiba_mica_lists_networks_options(){
       )
     ),
     'listOptions' => array(
+      'networkOptions' => array(
+        'showStudyBadge' => obiba_mica_lists_item_to_show($tabs_config, MicaListsHelper::TARGET_STUDY),
+        'showDatasetBadge' => obiba_mica_lists_item_to_show($tabs_config, MicaListsHelper::TARGET_DATASET),
+        'showVariableBadge' => obiba_mica_lists_item_to_show($tabs_config, MicaListsHelper::TARGET_VARIABLE),
+      ),
       'sortField' => array(
         'options' => array(
           array(
@@ -193,6 +210,7 @@ function obiba_mica_lists_networks_options(){
  */
 function obiba_mica_lists_studies_options($current_path){
   $acronym_name_sort = variable_get_value('study_list_name_acronym_sort');
+  $tabs_config = obiba_mica_lists_get_array_value_variable('mica_result_tabs_order');
   $studies_options = array(
     'listSearchOptions' => array(
       'study' => array(
@@ -212,6 +230,9 @@ function obiba_mica_lists_studies_options($current_path){
         'studiesSearchForm' => variable_get_value('studies_list_show_search_form'),
         'studiesSupplInfoDetails' => variable_get_value('studies_list_show_study_sup_info'),
         'studiesTrimmedDescription' => variable_get_value('studies_list_show_trimmed_description_study'),
+        'showNetworkBadge' => obiba_mica_lists_item_to_show($tabs_config, MicaListsHelper::TARGET_NETWORK),
+        'showDatasetBadge' => obiba_mica_lists_item_to_show($tabs_config, MicaListsHelper::TARGET_DATASET),
+        'showVariableBadge' => obiba_mica_lists_item_to_show($tabs_config, MicaListsHelper::TARGET_VARIABLE),
       ),
       'sortField' => array(
         'options' => array(
@@ -234,7 +255,10 @@ function obiba_mica_lists_studies_options($current_path){
       'studiesCountCaption' => variable_get_value('studies_list_show_studies_count_caption'),
       'studiesSearchForm' => variable_get_value('studies_list_show_search_form'),
       'studiesSupplInfoDetails' => variable_get_value('harmo_studies_list_show_study_sup_info'),
-      'studiesTrimmedDescription' => variable_get_value('harmo_studies_list_show_trimmed_description_study')
+      'studiesTrimmedDescription' => variable_get_value('harmo_studies_list_show_trimmed_description_study'),
+      'showNetworkBadge' => obiba_mica_lists_item_to_show($tabs_config, MicaListsHelper::TARGET_NETWORK),
+      'showDatasetBadge' => obiba_mica_lists_item_to_show($tabs_config, MicaListsHelper::TARGET_DATASET),
+      'showVariableBadge' => obiba_mica_lists_item_to_show($tabs_config, MicaListsHelper::TARGET_VARIABLE)
     );
   }
   return $studies_options;
@@ -244,6 +268,7 @@ function obiba_mica_lists_studies_options($current_path){
  * Networks list options
  */
 function obiba_mica_lists_datasets_options($current_path){
+  $tabs_config = obiba_mica_lists_get_array_value_variable('mica_result_tabs_order');
   $datasets_options = array(
     'listSearchOptions' => array(
       'dataset' => array(
@@ -265,6 +290,11 @@ function obiba_mica_lists_datasets_options($current_path){
       ),
     ),
     'listOptions' => array(
+      'datasetOptions' => array(
+        'showNetworkBadge' => obiba_mica_lists_item_to_show($tabs_config, MicaListsHelper::TARGET_NETWORK),
+        'showStudyBadge' => obiba_mica_lists_item_to_show($tabs_config, MicaListsHelper::TARGET_STUDY),
+        'showVariableBadge' => obiba_mica_lists_item_to_show($tabs_config, MicaListsHelper::TARGET_VARIABLE),
+      ),
       'sortField' => array(
         'options' => array(
           array(


### PR DESCRIPTION
Restore drupal config to hide dataset count in document list pages
ps: It more coherent if this config is belongs to List result targets order config options <DRUPAL> : admin/config/obiba-mica/obiba-search-pages-settings
    So if we disable one of the result targets tab (variable, network, study, or dataset) it disable its link on the list pages