### PR TITLE
#1572

### DIFF
--- a/obiba_mica.install
+++ b/obiba_mica.install
@@ -65,8 +65,8 @@ function obiba_mica_block_configuration() {
 function obiba_mica_theme_configuration() {
   variable_set('theme_default', 'obiba_bootstrap');
   variable_set('admin_theme', 'seven');
-  variable_set('jquery_update_jquery_version', '1.8');
-  variable_set('jquery_update_jquery_admin_version', '1.8');
+  variable_set('jquery_update_jquery_version', '1.10');
+  variable_set('jquery_update_jquery_admin_version', '1.10');
 
   variable_set('obiba-progressbar-lib-version', '1.0.1');
   variable_set('obiba-progressbar-lib', 'obiba-progressbar');

--- a/obiba_mica_app_angular/obiba_mica_app_angular.module
+++ b/obiba_mica_app_angular/obiba_mica_app_angular.module
@@ -72,21 +72,6 @@ function obiba_mica_app_angular_library() {
 }
 
 /**
- * Implements hook_library_alter().
- *
- * Angular library compatible with Jquery 1.10
- */
-function obiba_mica_app_angular_library_alter(&$javascript, $module) {
-  if (($module == 'obiba_mica_app_angular' || $module == 'system')
-    && current_path() == 'obiba-angular-app'
-  ) {
-    $path = drupal_get_path('module', 'jquery_update');
-    jquery_update_jquery_replace($javascript, NULL, $path, NULL, '1.10');
-  }
-
-}
-
-/**
  * Implements hook_theme().
  */
 function obiba_mica_app_angular_theme($existing, $type, $theme, $path) {
@@ -286,12 +271,6 @@ function obiba_mica_app_angular_load_angular_library() {
         $lib_path . '/es6-shim/es6-shim.js' => array(
           'type' => 'file',
           'scope' => 'footer',
-        ),
-        $lib_path . '/jquery-ui/jquery-ui.min.js' => array(
-          'type' => 'file',
-          'group' => JS_LIBRARY,
-          'weight' => 11
-
         ),
         $lib_path . '/angular/angular.min.js' => array(
           'type' => 'file',

--- a/obiba_mica_data_access_request/obiba_mica_data_access_request.module
+++ b/obiba_mica_data_access_request/obiba_mica_data_access_request.module
@@ -355,18 +355,6 @@ function obiba_mica_data_access_request_library() {
 }
 
 /**
- * Implements hook_library_alter().
- */
-function obiba_mica_data_access_request_library_alter(&$javascript, $module) {
-  if (($module == 'obiba_mica_data_access_request' || $module == 'system') &&
-    (current_path() == MicaClientPathProvider::DATA_ACCESS_REQUEST || current_path() == MicaClientPathProvider::DATA_ACCESS_LIST)) {
-    $path = drupal_get_path('module', 'jquery_update');
-    jquery_update_jquery_replace($javascript, NULL, $path, NULL, '1.10');
-  }
-
-}
-
-/**
  * Create/Update data access request node content page.
  */
 function obiba_mica_data_access_request() {


### PR DESCRIPTION
bug on Jquery on angular pages app
- The hook library alter are useless, as long as we use the jquery update Drupal module
- There are no reason to force to load the "/jquery-ui/jquery-ui.min.js" be cause it's loaded by default by the Bootstap drupal module