### PR TITLE
#1579

### DIFF
--- a/obiba_mica_commons/includes/obiba_mica_commons_resource_paths.inc
+++ b/obiba_mica_commons/includes/obiba_mica_commons_resource_paths.inc
@@ -39,10 +39,12 @@ class MicaClientPathHelpers {
    * Normalized the modal target to make a jQuery-safe reference.
    *
    * @param $target
+   * @param $isDce
    * @return mixed
    */
-  public static function normalizeModalTarget($target) {
-    return self::replacePlusInUrl(str_replace(' ', '_', preg_replace('/\./', '___', $target)));
+  public static function normalizeModalTarget($target, $isDce = NULL) {
+    return self::replacePlusInUrl(str_replace(' ', '_',
+      $isDce ? $target : preg_replace('/\./', '___', $target)));
   }
 }
 

--- a/obiba_mica_dataset/obiba_mica_dataset.module
+++ b/obiba_mica_dataset/obiba_mica_dataset.module
@@ -345,7 +345,8 @@ function obiba_mica_dataset_get_dce_from_dataset($dataset_summary, $study_id = N
                 'external' => TRUE,
                 'attributes' => array(
                   'data-toggle' => 'modal',
-                  'data-target' => DrupalMicaStudyResource::studyPopulationDceModalTarget($study_table->studyId, $study_table->populationId, $study_table->dataCollectionEventId),
+                  'data-dceid' => DrupalMicaStudyResource::studyPopulationDceModalTarget($study_table->studyId, $study_table->populationId, $study_table->dataCollectionEventId),
+                  'data-target' => '#dce-modal',
                 ),
               )) . '</li>';
             $dce_names[] = $dce_name;
@@ -366,7 +367,8 @@ function obiba_mica_dataset_get_dce_from_dataset($dataset_summary, $study_id = N
         'external' => TRUE,
         'attributes' => array(
           'data-toggle' => 'modal',
-          'data-target' => DrupalMicaStudyResource::studyPopulationDceModalTarget($study_table->studyId, $study_table->populationId, $study_table->dataCollectionEventId)
+          'data-dceid' => DrupalMicaStudyResource::studyPopulationDceModalTarget($study_table->studyId, $study_table->populationId, $study_table->dataCollectionEventId),
+          'data-target' => '#dce-modal',
         ),
       ));
       $have_dce = TRUE;

--- a/obiba_mica_study/includes/obiba_mica_study_resource.inc
+++ b/obiba_mica_study/includes/obiba_mica_study_resource.inc
@@ -334,7 +334,7 @@ class DrupalMicaStudyResource extends DrupalMicaClientResource {
    */
   public static function studyPopulationDceModalTarget($study_id, $population_id, $dce) {
     return MicaClientPathHelpers::normalizeModalTarget($study_id . ':' . $population_id . ':' .
-      (is_string($dce) ? $dce : $dce->id));
+      (is_string($dce) ? $dce : $dce->id), TRUE);
   }
 
   /**

--- a/obiba_mica_study/js/obiba-mica-study-timeline.js
+++ b/obiba_mica_study/js/obiba-mica-study-timeline.js
@@ -32,7 +32,7 @@
           id: '#dce-modal',
           study: study,
           pop: pop,
-          dceId: (study.id + ':' + pop.id + ':' + dce.id).replace(/\+/g, '-').replace(/\./, '___')
+          dceId: (study.id + ':' + pop.id + ':' + dce.id)
         };
         return modal;
       }

--- a/obiba_mica_study/obiba_mica_study-page-detail.inc
+++ b/obiba_mica_study/obiba_mica_study-page-detail.inc
@@ -482,7 +482,7 @@ function obiba_mica_study_get_dce_detail($study_resource_path, $study_id, $popul
       'study_id' => $study_id,
       'population_id' => $population_id,
       'dce_uid' => $study_id . ':' . $population_id . ':' . $dce->id,
-      'dce_id_target' => MicaClientPathHelpers::normalizeModalTarget($study_id . '-' . $population_id . '-' . $dce->id),
+      'dce_id_target' => MicaClientPathHelpers::normalizeModalTarget($study_id . '-' . $population_id . '-' . $dce->id, TRUE),
       'dce' => $dce,
       'file_browser' => !empty($file_browser) ? $file_browser : NULL,
     ));


### PR DESCRIPTION
Bug on DCE modal
Study page detail
The DCE modal details can't be displayed if dce-uid : xx.yy:zz:ww
the dce_uid supposed to be an like : xx__yy:zz:ww
Fix:
- Remove the replacement pattern : "." vs "__"
- Remove the replacement pattern : "+" vs "-" (Time line dce modal, the id's can't contain special characters)
- Fix the link open Modal on the Datasets tables