### PR TITLE
QA 30/05/2019 Maelstrom fix:

### DIFF
--- a/obiba_mica.variable.inc
+++ b/obiba_mica.variable.inc
@@ -31,7 +31,6 @@ function obiba_mica_variable_info($options) {
   _obiba_mica_variable_search_datasets($variable);
   _obiba_mica_variable_search_variables($variable);
   _obiba_mica_variable_network_content($variable);
-  _obiba_mica_variable_sets_sets_page($variable);
 
   $variable['mica_taxonomy_figures'] = array(
     'title' => t('Taxonomy in figures filter'),
@@ -137,25 +136,6 @@ function obiba_mica_variable_info($options) {
 }
 
 /**
- * Setting Variable Sets page
- */
-function _obiba_mica_variable_sets_sets_page(&$variable) {
-  $variable['help_text_cart_page'] = array(
-    'title' => t('Cart help text'),
-    'description' => t('Help text to display on the cart page.'),
-    'type' => 'string',
-    'default' => '',
-  );
-
-  $variable['help_text_sets_page'] = array(
-    'title' => t('List help text'),
-    'description' => t('Help text to display on the list page.'),
-    'type' => 'string',
-    'default' => '',
-  );
-}
-
-/**
  * Setting Variable search page.
  */
 function _obiba_mica_variable_search_page(&$variable) {
@@ -163,7 +143,17 @@ function _obiba_mica_variable_search_page(&$variable) {
     'title' => t('Search help text'),
     'description' => t('Help text to display on the search page.'),
     'type' => 'string',
-    'default' => '<p><i class="fa fa-info-circle"></i> The search page allows to browse catalogued information such as partner networks, studies, datasets and variables.</p><span class="anon-only"><p><i class="fa fa-shopping-cart fa-lg"></i> Discover the Custom Variables List feature by either <a href="user/login" class="redirection-place-holder">signing in</a> or <a href="agate/register#join" class="redirection-place-holder">registering</a></p></span>',
+    'default' => '<p><i class="fa fa-info-circle"></i> The search page allows to browse catalogued information such as partner networks, studies, datasets and variables.</p>
+                    <span class="anon-only">
+                    <p>
+                    <i class="fa fa-shopping-cart fa-lg"></i> 
+                    To save your variable search results, please <a href="/user/login" class="redirection-place-holder btn btn-success btn-xs">log in</a> 
+                    or <a href="/agate/register#join" class="redirection-place-holder btn btn-success btn-xs">register</a>
+                    <span>. Note that this feature is only available in the variable list.</span>
+                    </p></span>
+                    <span class="logged-in"><p><i class="fa fa-shopping-cart fa-lg"></i> 
+                    You are logged in and can save your variable search results. Note that this feature is only available in the variable list.</p></span>
+                    ',
   );
 
   $variable['help_text_harmonization_potential_page'] = array(

--- a/obiba_mica_app_angular/js/app/app.js
+++ b/obiba_mica_app_angular/js/app/app.js
@@ -377,4 +377,17 @@ mica.service('AttributeService',
         }
       }
     };
+  })
+  .directive('loggedIn', function() {
+    return {
+      restrict: 'AC',
+      link: function(scope, element, attrs) {
+        var isMicaUser = Drupal.settings.angularjsApp.authenticated && Drupal.settings.angularjsApp.agate_user;
+        if (!isMicaUser) {
+          element.hide();
+        } else {
+          element.show();
+        }
+      }
+    };
   });

--- a/obiba_mica_app_angular/obiba_mica_app_angular.module
+++ b/obiba_mica_app_angular/obiba_mica_app_angular.module
@@ -185,6 +185,7 @@ function obiba_mica_app_angular_load_js_resources($module_caller = NULL) {
       'show_detailed_stats' => variable_get_value('dataset_detailed_var_stats'),
       'data_access_config' => obiba_mica_app_angular_get_access_config(),
       'analysis_config' => obiba_mica_app_angular_get_analysis_config(),
+      'sets_config' => obiba_mica_app_angular_get_sets_config(),
       'obibaSearchOptions' => obiba_mica_app_angular_get_search_config(),
       'micaServerConfig' => empty($micaConfig) ? array() : $micaConfig
     ),
@@ -516,6 +517,16 @@ function obiba_mica_app_angular_get_analysis_config() {
 }
 
 /**
+ * Sets module settings.
+ */
+function obiba_mica_app_angular_get_sets_config() {
+  return array(
+    'CartHelpText' => variable_get_value('help_text_cart_page'),
+    'SetsHelpText' => variable_get_value('help_text_sets_page'),
+  );
+}
+
+/**
  * Search Module settings
  */
 function obiba_mica_app_angular_get_search_config() {
@@ -541,8 +552,6 @@ function obiba_mica_app_angular_get_search_config() {
   )));
   return array(
     'SearchHelpText' => variable_get_value('help_text_search_page'),
-    'CartHelpText' => variable_get_value('help_text_cart_page'),
-    'SetsHelpText' => variable_get_value('help_text_sets_page'),
     'ClassificationHelpText' => variable_get_value('help_text_harmonization_potential_page'),
     'SearchHelpLinkLabel' => variable_get_value('help_link_label'),
     'SearchHelpLinkUrl' => variable_get_value('help_link_url'),

--- a/obiba_mica_commons/obiba_mica_commons.module
+++ b/obiba_mica_commons/obiba_mica_commons.module
@@ -810,8 +810,10 @@ function obiba_mica_commons_get_translated_node($nid) {
  */
 function obiba_mica_commons_is_authorized_agate_user() {
   global $user;
-
-  if (!empty($user->session) && strstr($user->session, 'obibaid')) {
+  $path_array = array();
+  $path_array = explode('/', current_path());
+  //Make sure that access is authorized for administrator account in admin configuration UI only
+  if ((!empty($user->session) && strstr($user->session, 'obibaid')) || (user_access('access administration pages') && $path_array[0] == "admin")) {
     return TRUE;
   }
   return FALSE;

--- a/obiba_mica_sets/js/app/obiba-sets.js
+++ b/obiba_mica_sets/js/app/obiba-sets.js
@@ -17,6 +17,6 @@ mica.ObibaSets = angular.module('mica.ObibaSets', [
       ngObibaMicaSetsTemplateUrlProvider.setHeaderUrl('cart', Drupal.settings.basePath + 'obiba_mica_app_angular_view_template/obiba_mica_sets_cart-view-header');
       ngObibaMicaSetsTemplateUrlProvider.setHeaderUrl('sets', Drupal.settings.basePath + 'obiba_mica_app_angular_view_template/obiba_mica_sets_sets-view-header');
     }])
-    .run(['AnalysisConfigService', function(AnalysisConfigService) {
-      AnalysisConfigService.setOptions(Drupal.settings.angularjsApp.analysis_config);
+    .run(['SetService', function(SetService) {
+      SetService.setSettingOption(Drupal.settings.angularjsApp.sets_config);
     }]);

--- a/obiba_mica_sets/obiba_mica_sets.admin.inc
+++ b/obiba_mica_sets/obiba_mica_sets.admin.inc
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Copyright (c) 2018 OBiBa. All rights reserved.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the GNU Public License v3.0.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file
+ * Obiba Mica Analysis module variable file
+ */
+
+/**
+ * Provides settings pages.
+ */
+function obiba_mica_sets_admin_settings() {
+  $form['obiba_mica_sets'] = array(
+    '#type' => 'vertical_tabs',
+    '#title' => t('Sets display settings'),
+    '#collapsible' => FALSE,
+  );
+
+  $form['obiba_mica_sets']['sets_display'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Sets display'),
+    '#collapsible' => FALSE,
+  );
+
+  $info = variable_get_info('help_text_cart_page');
+  $form['obiba_mica_sets']['sets_display']['help_text_cart_page'] = array(
+    '#type' => 'textfield',
+    '#title' => $info['title'],
+    '#required' => FALSE,
+    '#default_value' => variable_get_value('help_text_cart_page'),
+    '#maxlength' => 255,
+    '#description' => $info['description'],
+  );
+  $info = variable_get_info('help_text_sets_page');
+  $form['obiba_mica_sets']['sets_display']['help_text_sets_page'] = array(
+    '#type' => 'textfield',
+    '#title' => $info['title'],
+    '#required' => FALSE,
+    '#default_value' => variable_get_value('help_text_sets_page'),
+    '#maxlength' => 255,
+    '#description' => $info['description'],
+  );
+
+  return system_settings_form($form);
+}

--- a/obiba_mica_sets/obiba_mica_sets.module
+++ b/obiba_mica_sets/obiba_mica_sets.module
@@ -15,6 +15,17 @@
 function obiba_mica_sets_menu() {
   $items = array();
 
+  $items['admin/config/obiba-mica/obiba-mica-sets-settings'] = array(
+    'title' => 'Sets settings',
+    'description' => 'Configure Sets pages.',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('obiba_mica_sets_admin_settings'),
+    'access arguments' => array('administer obiba mica'),
+    'type' => MENU_NORMAL_ITEM,
+    'file' => 'obiba_mica_sets.admin.inc',
+    'weight' => 3,
+  );
+
   $items[ObibaSetsResources::MICA_SETS . '/%/sets/ws'] = array(
     'page callback' => 'obiba_mica_sets_list_sets',
     'file' => 'obiba_mica_sets_services.inc',
@@ -111,8 +122,8 @@ function obiba_mica_sets_load_menus() {
     'access callback' => TRUE,
     'title' => variable_get('cart_page_title', 'Cart'),
     'module_caller' => 'obiba_mica_sets',
-      'type' => MENU_CALLBACK,
-      'options' => array('fragment' => 'cart'),
+    'type' => MENU_CALLBACK,
+    'options' => array('fragment' => 'cart'),
   );
 
   $items[MicaClientPathProvider::SETS] = array(

--- a/obiba_mica_sets/obiba_mica_sets.variable.inc
+++ b/obiba_mica_sets/obiba_mica_sets.variable.inc
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Implements hook_variable_info().
+ */
+function obiba_mica_sets_variable_info($variable) {
+  $variable['help_text_cart_page'] = array(
+    'title' => t('Cart help text'),
+    'description' => t('Help text to display on the cart page.'),
+    'type' => 'string',
+    'default' => 'Use the cart to make a list of variables. This list can be analyzed or can be viewed in the search page.',
+  );
+
+  $variable['help_text_sets_page'] = array(
+    'title' => t('List help text'),
+    'description' => t('Help text to display on the list page.'),
+    'type' => 'string',
+    'default' => 'Make one or more lists. Each list can be analyzed or can be viewed in the search page.',
+  );
+
+  return $variable;
+}

--- a/obiba_mica_study/templates/study-detail/obiba_mica_study-detail-access.tpl.php
+++ b/obiba_mica_study/templates/study-detail/obiba_mica_study-detail-access.tpl.php
@@ -73,7 +73,7 @@ $icon = function($value){
 <!--    General information-->
   <div class="tab-pane active lg-top-padding lg-right-indent" role="tabpanel" aria-labelledby="general-tab" id="general">
       <label><?php print $localize->getTranslation('study.access.access_external_researchers_permitted_foreseen.title') ?></label>
-    <div class="table-responsive lg-bottom-margin">
+    <div class="table-responsive">
       <table class="table table-striped valign-table-column">
         <tbody>
         <tr>
@@ -212,20 +212,28 @@ $icon = function($value){
 <!--    fees-->
   <?php if (!empty($study_dto->model->access_fees)): ?>
     <div class="tab-pane lg-top-padding lg-right-indent" role="tabpanel" aria-labelledby="fees-tab"  id="fees" >
+      <?php if (!empty($study_dto->model->access_data_sharing_cost->data) || !empty($study_dto->model->access_data_sharing_cost->biological_samples)): ?>
         <label ><?php print $localize->getTranslation('study.access.access_data_sharing_cost.cost-title') ?></label>
-        <p>
-          <?php if (!empty($study_dto->model->access_data_sharing_cost->data)): ?>
-            <?php print $localize->getTranslation('study_taxonomy.vocabulary.access_data.title') ?>: <?php print $localize->getTranslation('study.access.access_data_sharing_cost.'.$study_dto->model->access_data_sharing_cost->data) ?>
-          <?php endif; ?>
-        </p>
-        <p class="lg-bottom-margin">
-      <?php if (!empty($study_dto->model->access_data_sharing_cost->biological_samples)): ?>
-        <?php print $localize->getTranslation('study_taxonomy.vocabulary.access_bio_samples.title') ?>: <?php print $localize->getTranslation('study.access.access_data_sharing_cost.'.$study_dto->model->access_data_sharing_cost->biological_samples) ?>
+        <table class="table table-striped valign-table-column">
+            <tbody>
+            <?php if (!empty($study_dto->model->access_data_sharing_cost->data)): ?>
+            <tr>
+                <td> <?php print $localize->getTranslation('study_taxonomy.vocabulary.access_data.title') ?></td>
+                <td><?php print $localize->getTranslation('study.access.access_data_sharing_cost.'.$study_dto->model->access_data_sharing_cost->data) ?></td>
+            </tr>
+            <?php endif; ?>
+            <?php if (!empty($study_dto->model->access_data_sharing_cost->biological_samples)): ?>
+            <tr>
+                <td><?php print $localize->getTranslation('study_taxonomy.vocabulary.access_bio_samples.title') ?></td>
+                <td><?php print $localize->getTranslation('study.access.access_data_sharing_cost.'.$study_dto->model->access_data_sharing_cost->biological_samples) ?></td>
+            </tr>
+            <?php endif; ?>
+            </tbody>
+        </table>
       <?php endif; ?>
-        </p>
-
+      <?php if (!empty($study_dto->model->access_cost_reduction_consideration->data) || !empty($study_dto->model->access_cost_reduction_consideration->bio_samples)): ?>
         <label ><?php print $localize->getTranslation('study.access.access_data_sharing_cost.cost-reduction-title') ?></label>
-        <div class="table-responsive lg-bottom-margin">
+        <div class="table-responsive">
             <table class="table table-striped valign-table-column">
                 <tbody>
                 <tr>
@@ -250,6 +258,7 @@ $icon = function($value){
                 </tbody>
             </table>
         </div>
+      <?php endif; ?>
       <?php if (!empty($study_dto->model->access_cost_reduction_consideration_specification)): ?>
           <label ><?php print $localize->getTranslation('study.access.access_cost_reduction_consideration_specification.title') ?></label>
         <p class="lg-bottom-margin">


### PR DESCRIPTION
- Help text on search page display hide depending if user logged in or not
- Help text in list/cart page is not configurable (Only translation is considered)
- List menu can't be configured (permission logic) so can't be hide
- Access section in study detail page UI