### PR TITLE
Config min variable number in harmonized dataset

### DIFF
--- a/obiba_mica_dataset/obiba_mica_dataset.module
+++ b/obiba_mica_dataset/obiba_mica_dataset.module
@@ -408,7 +408,8 @@ function obiba_mica_dataset_get_datasets_list_tab($datasets, $study_id) {
     foreach ($summaries as $key_dataset => $summary) {
       $dataset_description = NULL;
 
-      if (!empty($summary->{'obiba.mica.CountStatsDto.datasetCountStats'}->variables)) {
+      if (!empty($summary->{'obiba.mica.CountStatsDto.datasetCountStats'}->variables) &&
+          $summary->{'obiba.mica.CountStatsDto.datasetCountStats'}->variables > theme_get_setting('obiba_mica_min_var_dataset')) {
         $variable_nbr_row = $summary->{'obiba.mica.CountStatsDto.datasetCountStats'}->variables;
         $nb_variables = MicaClientAnchorHelper::datasetVariables(
           obiba_mica_commons_format_number($variable_nbr_row),
@@ -416,7 +417,9 @@ function obiba_mica_dataset_get_datasets_list_tab($datasets, $study_id) {
           array(),
           'study(in(Mica_study.id,' . $study_id . '))'
         );
-
+      }
+      else {
+        $nb_variables = '-';
       }
       $dce_name_array = obiba_mica_dataset_get_dce_from_dataset($summary, $study_id);
       if (!empty($variable_nbr_row)) {


### PR DESCRIPTION
Fix to configure the display of the number of variables in Harmonization table ->  Harmonized Studies page
If the config doesn't exist the default behavior is taken
This configuration should be implemented on the custom Obiba Bootstrap theme that have overridden Harmonized Dataset template page